### PR TITLE
Error when work with vue-router fix

### DIFF
--- a/src/scrollactive.vue
+++ b/src/scrollactive.vue
@@ -205,6 +205,11 @@
 					scrollactiveItem.addEventListener('click', this.scrollToTargetElement);
 				}
 			}
+		},
+
+		beforeDestroy () {
+			window.removeEventListener('scroll', this.onScroll);
+			window.cancelAnimationFrame(window.AFRequestID);
 		}
 	}
 </script>

--- a/src/scrollactive.vue
+++ b/src/scrollactive.vue
@@ -105,7 +105,7 @@
 		methods: {
 			onScroll() {
 				for (let scrollactiveItem of this.scrollactiveItems) {
-					let target = document.querySelector(scrollactiveItem.hash);
+					let target = document.getElementById(scrollactiveItem.hash.substr(1));
 
 					if (this.isWindowInsideTarget(target)) {
 						scrollactiveItem.classList.add(this.activeClass);
@@ -141,7 +141,7 @@
 				}
 
 				for (let scrollactiveItem of scrollactiveItems) {
-					if (!document.querySelector(scrollactiveItem.hash)) {
+					if (!document.getElementById(scrollactiveItem.hash.substr(1))) {
 						throw new Error("Element '" + scrollactiveItem.hash + "' was not found. Make sure it is set in the DOM.");
 					}
 				}
@@ -164,7 +164,7 @@
 				}
 
 				let vm = this;
-				let targetDistanceFromTop = document.querySelector(event.target.hash).offsetTop;
+				let targetDistanceFromTop = document.getElementById(event.target.hash.substr(1)).offsetTop;
 				let startingY = window.pageYOffset;
 				let difference = targetDistanceFromTop - startingY;
 				let start = null;


### PR DESCRIPTION
This branch contains two commits, each of which solves a conflict with [vue-router](https://github.com/vuejs/vue-router), the official router for [Vue.js](https://vuejs.org/). The implementation and reasons are explained as below.

## Remove registered event listener at `beforeDestory()`

I remove registered `scroll` event listener at `beforeDestroy()` hook. Such listener is registered in `mounted()` function.

Without the removal of such listener, previous implementation could result in a bunch of error message in debug console, such as:
```
Uncaught TypeError: Cannot read property 'offsetTop' of null
    at VueComponent.isWindowInsideTarget (eval at <anonymous> (build.js:1531), <anonymous>:138:38)
    at VueComponent.boundFn [as isWindowInsideTarget] (eval at <anonymous> (build.js:912), <anonymous>:164:14)
    at VueComponent.onScroll (eval at <anonymous> (build.js:1531), <anonymous>:121:14)
    at boundFn (eval at <anonymous> (build.js:912), <anonymous>:165:14)
```
when switch from a route with the component to another without and switch back in vue-router.

## Using `document.getElementId()` instead of `document.querySelector()`

Using `document.getElementById()` instead of `document.querySelector()` while search element from hash. While using `document.querySelector()`, the css id query string needs extra escaping, when there is special characters. This could be extremely true while working with vue-router, where each hash start with slash. Such hash could be `#/example#element-id`, when a route path is actually `/example`.

In my implementtation, I firstly ripped off the hash sign with `string.substr(1)`, and use the latter string as element id. With `document.getElementById()`, things work out fine.

This implement looks quite dirty though.