### PR TITLE
#3 Fix for Firefox 55 and IE11

### DIFF
--- a/src/scrollactive.vue
+++ b/src/scrollactive.vue
@@ -109,7 +109,7 @@
 			 * the addition of the active class in the current section item
 			 * and fire the change event.
 			 */
-			onScroll() {
+			onScroll(event) {
 				let distanceFromTop = window.scrollY;
 				let currentItem;
 


### PR DESCRIPTION
It seems the missing "event" reference in the onScroll cause issue on Firefox and IE11... 

This may be related to `webpack` or `laravel-mix`

This anyway should fix #3