### PR TITLE
Add support for detecting block overshooting the offset

### DIFF
--- a/dist/vue-scrollactive.js
+++ b/dist/vue-scrollactive.js
@@ -70,52 +70,44 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	__webpack_require__.p = "/dist/";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 23);
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
 /******/ })
 /************************************************************************/
-/******/ ({
-
-/***/ 23:
-/***/ (function(module, exports, __webpack_require__) {
+/******/ ([
+/* 0 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__scrollactive_vue__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__scrollactive_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__scrollactive_vue__);
 
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
+const Plugin = {};
 
-var _scrollactive = __webpack_require__(24);
-
-var _scrollactive2 = _interopRequireDefault(_scrollactive);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-var Plugin = {};
-
-Plugin.install = function (Vue) {
+Plugin.install = (Vue) => {
   if (Plugin.install.installed) return;
 
-  Vue.component('scrollactive', _scrollactive2.default);
+  Vue.component('scrollactive', __WEBPACK_IMPORTED_MODULE_0__scrollactive_vue___default.a);
 };
 
 if (typeof window !== 'undefined' && window.Vue) {
   Plugin.install(window.Vue);
 }
 
-exports.default = Plugin;
+/* harmony default export */ __webpack_exports__["default"] = (Plugin);
+
 
 /***/ }),
-
-/***/ 24:
+/* 1 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var disposed = false
-var Component = __webpack_require__(25)(
+var Component = __webpack_require__(2)(
   /* script */
-  __webpack_require__(26),
+  __webpack_require__(3),
   /* template */
-  __webpack_require__(58),
+  __webpack_require__(5),
   /* styles */
   null,
   /* scopeId */
@@ -123,13 +115,13 @@ var Component = __webpack_require__(25)(
   /* moduleIdentifier (server only) */
   null
 )
-Component.options.__file = "/Users/mauricio/web/vue-scrollactive/src/scrollactive.vue"
+Component.options.__file = "/Users/thomasmery/Documents/WebDev/Clients/C&I/cominst.com/v2/application/web/app/themes/cominst/node_modules/vue-scrollactive/src/scrollactive.vue"
 if (Component.esModule && Object.keys(Component.esModule).some(function (key) {return key !== "default" && key.substr(0, 2) !== "__"})) {console.error("named exports are not supported in *.vue files.")}
 if (Component.options.functional) {console.error("[vue-loader] scrollactive.vue: functional components are not supported with templates, they should use render functions.")}
 
 /* hot reload */
 if (false) {(function () {
-  var hotAPI = require("vue-hot-reload-api")
+  var hotAPI = require("vue-loader/node_modules/vue-hot-reload-api")
   hotAPI.install(require("vue"), false)
   if (!hotAPI.compatible) return
   module.hot.accept()
@@ -147,8 +139,7 @@ module.exports = Component.exports
 
 
 /***/ }),
-
-/***/ 25:
+/* 2 */
 /***/ (function(module, exports) {
 
 /* globals __VUE_SSR_CONTEXT__ */
@@ -245,8 +236,7 @@ module.exports = function normalizeComponent (
 
 
 /***/ }),
-
-/***/ 26:
+/* 3 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -256,7 +246,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _bezierEasing = __webpack_require__(57);
+var _bezierEasing = __webpack_require__(4);
 
 var _bezierEasing2 = _interopRequireDefault(_bezierEasing);
 
@@ -377,7 +367,13 @@ exports.default = {
         scrollactiveItem.classList.remove(_this.activeClass);
         var target = document.getElementById(scrollactiveItem.hash.substr(1));
 
-        if (distanceFromTop >= _this.getOffsetTop(target) - _this.offset) {
+        var isInView = false;
+        var itemInViewTop = _this.getOffsetTop(target) - _this.offset;
+        var itemInViewBottom = itemInViewTop + target.clientHeight;
+
+        isInView = distanceFromTop >= itemInViewTop && distanceFromTop < itemInViewBottom;
+
+        if (isInView) {
           currentItem = scrollactiveItem;
         }
       });
@@ -511,8 +507,7 @@ exports.default = {
 //
 
 /***/ }),
-
-/***/ 57:
+/* 4 */
 /***/ (function(module, exports) {
 
 /**
@@ -622,8 +617,7 @@ module.exports = function bezier (mX1, mY1, mX2, mY2) {
 
 
 /***/ }),
-
-/***/ 58:
+/* 5 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
@@ -635,11 +629,10 @@ module.exports.render._withStripped = true
 if (false) {
   module.hot.accept()
   if (module.hot.data) {
-     require("vue-hot-reload-api").rerender("data-v-75a6c496", module.exports)
+     require("vue-loader/node_modules/vue-hot-reload-api").rerender("data-v-75a6c496", module.exports)
   }
 }
 
 /***/ })
-
-/******/ });
+/******/ ]);
 });

--- a/dist/vue-scrollactive.min.js
+++ b/dist/vue-scrollactive.min.js
@@ -70,52 +70,44 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	__webpack_require__.p = "/dist/";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 23);
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
 /******/ })
 /************************************************************************/
-/******/ ({
-
-/***/ 23:
-/***/ (function(module, exports, __webpack_require__) {
+/******/ ([
+/* 0 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__scrollactive_vue__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__scrollactive_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__scrollactive_vue__);
 
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
+const Plugin = {};
 
-var _scrollactive = __webpack_require__(24);
-
-var _scrollactive2 = _interopRequireDefault(_scrollactive);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-var Plugin = {};
-
-Plugin.install = function (Vue) {
+Plugin.install = (Vue) => {
   if (Plugin.install.installed) return;
 
-  Vue.component('scrollactive', _scrollactive2.default);
+  Vue.component('scrollactive', __WEBPACK_IMPORTED_MODULE_0__scrollactive_vue___default.a);
 };
 
 if (typeof window !== 'undefined' && window.Vue) {
   Plugin.install(window.Vue);
 }
 
-exports.default = Plugin;
+/* harmony default export */ __webpack_exports__["default"] = (Plugin);
+
 
 /***/ }),
-
-/***/ 24:
+/* 1 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var disposed = false
-var Component = __webpack_require__(25)(
+var Component = __webpack_require__(2)(
   /* script */
-  __webpack_require__(26),
+  __webpack_require__(3),
   /* template */
-  __webpack_require__(58),
+  __webpack_require__(5),
   /* styles */
   null,
   /* scopeId */
@@ -123,13 +115,13 @@ var Component = __webpack_require__(25)(
   /* moduleIdentifier (server only) */
   null
 )
-Component.options.__file = "/Users/mauricio/web/vue-scrollactive/src/scrollactive.vue"
+Component.options.__file = "/Users/thomasmery/Documents/WebDev/Clients/C&I/cominst.com/v2/application/web/app/themes/cominst/node_modules/vue-scrollactive/src/scrollactive.vue"
 if (Component.esModule && Object.keys(Component.esModule).some(function (key) {return key !== "default" && key.substr(0, 2) !== "__"})) {console.error("named exports are not supported in *.vue files.")}
 if (Component.options.functional) {console.error("[vue-loader] scrollactive.vue: functional components are not supported with templates, they should use render functions.")}
 
 /* hot reload */
 if (false) {(function () {
-  var hotAPI = require("vue-hot-reload-api")
+  var hotAPI = require("vue-loader/node_modules/vue-hot-reload-api")
   hotAPI.install(require("vue"), false)
   if (!hotAPI.compatible) return
   module.hot.accept()
@@ -147,8 +139,7 @@ module.exports = Component.exports
 
 
 /***/ }),
-
-/***/ 25:
+/* 2 */
 /***/ (function(module, exports) {
 
 /* globals __VUE_SSR_CONTEXT__ */
@@ -245,8 +236,7 @@ module.exports = function normalizeComponent (
 
 
 /***/ }),
-
-/***/ 26:
+/* 3 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -256,7 +246,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _bezierEasing = __webpack_require__(57);
+var _bezierEasing = __webpack_require__(4);
 
 var _bezierEasing2 = _interopRequireDefault(_bezierEasing);
 
@@ -377,7 +367,13 @@ exports.default = {
         scrollactiveItem.classList.remove(_this.activeClass);
         var target = document.getElementById(scrollactiveItem.hash.substr(1));
 
-        if (distanceFromTop >= _this.getOffsetTop(target) - _this.offset) {
+        var isInView = false;
+        var itemInViewTop = _this.getOffsetTop(target) - _this.offset;
+        var itemInViewBottom = itemInViewTop + target.clientHeight;
+
+        isInView = distanceFromTop >= itemInViewTop && distanceFromTop < itemInViewBottom;
+
+        if (isInView) {
           currentItem = scrollactiveItem;
         }
       });
@@ -511,8 +507,7 @@ exports.default = {
 //
 
 /***/ }),
-
-/***/ 57:
+/* 4 */
 /***/ (function(module, exports) {
 
 /**
@@ -622,8 +617,7 @@ module.exports = function bezier (mX1, mY1, mX2, mY2) {
 
 
 /***/ }),
-
-/***/ 58:
+/* 5 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
@@ -635,11 +629,10 @@ module.exports.render._withStripped = true
 if (false) {
   module.hot.accept()
   if (module.hot.data) {
-     require("vue-hot-reload-api").rerender("data-v-75a6c496", module.exports)
+     require("vue-loader/node_modules/vue-hot-reload-api").rerender("data-v-75a6c496", module.exports)
   }
 }
 
 /***/ })
-
-/******/ });
+/******/ ]);
 });

--- a/src/scrollactive.vue
+++ b/src/scrollactive.vue
@@ -119,8 +119,15 @@ export default {
         scrollactiveItem.classList.remove(this.activeClass);
         const target = document.getElementById(scrollactiveItem.hash.substr(1));
 
-        if (distanceFromTop >= this.getOffsetTop(target) - this.offset) {
-          currentItem = scrollactiveItem;
+        let isInView = false;
+        let itemInViewTop = this.getOffsetTop(target) - this.offset;
+        let itemInViewBottom = itemInViewTop + target.clientHeight;
+
+        isInView = distanceFromTop >= itemInViewTop
+            && distanceFromTop < itemInViewBottom;
+
+        if (isInView) {
+            currentItem = scrollactiveItem;
         }
       });
 


### PR DESCRIPTION
Hi there,

thanks for this project, really helps,

I was in need to detect when the target overshoots the offset
so I added the proposed change

it also adds the ability to have the scrollactive-items in any order which was not the case before I believe

let me know what you think and if you can have a look

I tried to build your examples but got an error relating to sass-loader

```
ERROR in ./examples/src/main.scss
Module parse failed: /Users/thomasmery/Documents/WebDev/Clients/C&I/cominst.com/v2/application/web/app/themes/cominst/node_modules/vue-scrollactive/examples/src/main.scss Unexpected character '@' (1:0)
You may need an appropriate loader to handle this file type.
| @import "normalize";
|
| .nav.is-fixed {
 @ multi ./examples/src/main.js ./examples/src/main.scss
```
maybe you know how to fix this so I can test with your examples

