### PR TITLE
added scrollOnStart option to enable/disable scrolling on mounting

### DIFF
--- a/src/scrollactive.vue
+++ b/src/scrollactive.vue
@@ -150,6 +150,17 @@
         type: String,
         default: 'nav',
       },
+
+      /**
+      * Scroll to the anchor present if the current URL when the component is mounted.
+      *
+      * @default true
+      * @type {Boolean}
+      */
+      scrollOnStart: {
+        type: Boolean,
+        default: true,
+      },
     },
 
     data() {
@@ -202,7 +213,7 @@
 
       if (this.currentItem) this.currentItem.classList.add(this.activeClass);
 
-      this.scrollToHashElement();
+      if (this.scrollOnStart) this.scrollToHashElement();
       this.scrollContainer.addEventListener('scroll', this.onScroll);
     },
 


### PR DESCRIPTION
Hi,

I like your plugin and I added a property to disable automatic scrolling to the current URL's anchor, if any. It is enabled by default, but I needed to prevent that in my application.